### PR TITLE
Don't reorderer chromosomes

### DIFF
--- a/pararead/processor.py
+++ b/pararead/processor.py
@@ -330,6 +330,9 @@ class ParaReadProcessor(object):
         # unaligned files, which is occasionally desirable.
         builder = reads_file_maker.ctor
         kwargs = file_builder_kwargs
+
+        # Builder has minimal requirements that must be met.
+        # Thus, those take precedence over user provisions.
         kwargs.update(reads_file_maker.kwargs)
 
         if not self.require_aligned:


### PR DESCRIPTION
User time was roughly comparable but real time was faster previously on a ratbrain sample. Dropping the attempt to reorder reads chunks in pararead brings these more into line with one another.