### PR TITLE
Handle empty chromosomes

### DIFF
--- a/pararead/processor.py
+++ b/pararead/processor.py
@@ -455,9 +455,11 @@ class ParaReadProcessor(object):
             pass
 
         # TODO: handle non-chromosome-based case.
+        idxstats = readsfile.get_index_statistics()
+        reads_by_chrom = {istat.contig: istat.total for istat in idxstats}
         empties, nonempties = [], []
         for c in read_chunk_keys:
-            target = empties if 0 == self.get_chrom_size(c) else nonempties
+            target = empties if 0 == reads_by_chrom[c] else nonempties
             target.append(c)
 
         # Maps for order preservation. This permits arbitrary result return,
@@ -478,7 +480,7 @@ class ParaReadProcessor(object):
 
         # TODO: note the dependence on order here.
         result_by_chunk = [(c, self.empty_action(c)) for c in empties] + \
-                          list(zip(nonempties, results))
+                           list(zip(nonempties, results))
         bad_chunks, good_chunks = \
                 partition_chunks_by_null_result(result_by_chunk)
 

--- a/pararead/processor.py
+++ b/pararead/processor.py
@@ -238,6 +238,28 @@ class ParaReadProcessor(object):
         return self.fetch_file(READS_FILE_KEY)
 
 
+    @staticmethod
+    def empty_action(read_chunk_key=None):
+        """
+        Action to take when processing an empty reads chunk.
+
+        Parameters
+        ----------
+        read_chunk_key: str, optional
+            Key for the empty chunk of reads.
+
+        Returns
+        -------
+        NoneType
+            Null value is a ParaReadProcessor's default return for processing
+            an empty reads chunk.
+
+        """
+        if read_chunk_key:
+            _LOGGER.debug("Empty read chunk: {}".format(read_chunk_key))
+        return None
+
+
     def fetch_file(self, file_key):
         """
         Retrieve one of the files registered with pararead.
@@ -432,6 +454,12 @@ class ParaReadProcessor(object):
         except AttributeError:
             pass
 
+        # TODO: handle non-chromosome-based case.
+        empties, nonempties = [], []
+        for c in read_chunk_keys:
+            target = empties if 0 == self.get_chrom_size(c) else nonempties
+            target.append(c)
+
         # Maps for order preservation. This permits arbitrary result return,
         # i.e. something other than the chunk key itself, when the process
         # completes. It would be a bit simpler to filter on the results
@@ -440,15 +468,17 @@ class ParaReadProcessor(object):
         # for a particular chunk ID. That is, it may produce a result with
         # downstream meaning, and not be used simply for effect on disk.
         if self.cores == 1:
-            results = map(self, read_chunk_keys)
+            results = map(self, nonempties)
         else:
             workers = multiprocessing.Pool(self.cores)
             # The typical call to map fails to acknowledge KeyboardInterrupts.
             # This fix helps: http://stackoverflow.com/a/1408476/946721
-            results = workers.map_async(self, read_chunk_keys).get(9999999)
+
+            results = workers.map_async(self, nonempties).get(9999999)
 
         # TODO: note the dependence on order here.
-        result_by_chunk = zip(read_chunk_keys, results)
+        result_by_chunk = [(c, self.empty_action(c)) for c in empties] + \
+                          list(zip(nonempties, results))
         bad_chunks, good_chunks = \
                 partition_chunks_by_null_result(result_by_chunk)
 
@@ -474,20 +504,12 @@ class ParaReadProcessor(object):
         Iterable of pysam.AlignedSegment
 
         """
-
         if not self.by_chromosome:
             raise NotImplementedError(
                     "Provide a fetch_chunk implementation "
                     "if not partitioning reads by chromosome.")
-
         readsfile = PARA_READ_FILES[READS_FILE_KEY]
-
-        # Return the chunk of reads for the given chromosome if and only
-        # if it's nonempty. Otherwise, return None.
-        if 0 == readsfile.count(chromosome):
-            return []
-        else:
-            return readsfile.fetch(chromosome, multiple_iterators=True)
+        return readsfile.fetch(chromosome, multiple_iterators=True)
 
 
     def combine(self, good_chromosomes, strict=False):


### PR DESCRIPTION
Previously, it was troublesome (e.g., in `ATACSeq`'s `bamSitesToWig.py`) to do expensive setup instructions for processing reads from a chromosome, only to have it be empty. While it's possible to check for this condition on the return value from a call to `fetch_chunk` on a `ParaReadProcessor`, doing so isn't totally satisfactory since it necessitates either checking for a different return type (in the case of returning an empty list) or doing a check-for-null operation (in case of returning `None`.)

The first such option leads to a bizarre alternate code branch in the case of a `list` return type while preserving the ability for other implementors of a `ParaReadProcessor` to continue to rely on the knowledge that the value returned from `fetch_chunk` will be an iterable. Conversely, the `None` return option precludes implementors from being able to have a guarantee that using iteratable syntax on the returned value will be type-safe, but it's a more natural condition to check for.

Rather than adopt either of these incompletely satisfactory solutions, the changes here never bother with an attempt to apply the processor's `__call__` function to a chromosome to which no reads were mapped. Instead, provided here is a default action to take for each such chromosome, unburdening `ParaReadProcessor` implementors of the need to handle the possibility of an empty chromosome in their type's `__call__` implementation while allowing them to control the handling of empty chromosomes with the `empty_action` method via an override.